### PR TITLE
update espower-source to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "convert-source-map": "^1.0.0",
-    "espower-source": "^0.10.0"
+    "espower-source": "^1.0.0"
   }
 }


### PR DESCRIPTION
update espower-source to ^1.0.0

In addition to this change, I'd like to pass `sourceRoot` option to `espowerSource` function just like [espowerify](https://github.com/power-assert-js/espowerify/blob/master/index.js#L54) and others, to display relative paths.

Is there any nice way to retrieve project base path from karma? > @vvakame 
