### PR TITLE
fix: replace `helper._.clone` with `helper.merge`

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var createPreprocessor = function(args, config, logger, helper) {
         log.debug('Processing "%s".', file.originalPath);
         file.path = transformPath(file.originalPath);
 
-        var opts = helper._.clone(options);
+        var opts = helper.merge({}, options);
         if (opts.ignoreUpstreamSourceMap && file.sourceMap) {
             log.debug("detected upstream sourceMap info, but ignoring");
         } else if (file.sourceMap) {


### PR DESCRIPTION
since [`helper._` has been marked as deprecated](https://github.com/karma-runner/karma/commit/5c6b151) and removed from [new Karma 2.0.0 release](https://github.com/karma-runner/karma/blob/master/CHANGELOG.md#200-2017-12-21), and it's just a shallow copy.

refs: #3