### PR TITLE
fix: bump version of espower-source

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "convert-source-map": "^1.0.0",
-    "espower-source": "^1.0.0"
+    "espower-source": "^2.2.0"
   }
 }


### PR DESCRIPTION
The breaking change at v2 of `espower-source` doesn't affect this module, so we just could bump the version of it.

Fixes: https://github.com/power-assert-js/karma-espower-preprocessor/issues/5